### PR TITLE
Fix the condition to show the "partial report" button

### DIFF
--- a/src/codeclarity_components/projects/list/components/AnalysisItem.vue
+++ b/src/codeclarity_components/projects/list/components/AnalysisItem.vue
@@ -280,7 +280,8 @@ getChart(props.projectID, props.analysis.id);
                     props.analysis.status == AnalysisStatus.FINISHED ||
                     props.analysis.status == AnalysisStatus.COMPLETED ||
                     (props.analysis.status == AnalysisStatus.STARTED &&
-                        props.analysis.steps.length > 0)
+                        props.analysis.steps[0][0].Result != null) ||
+                    props.analysis.status == AnalysisStatus.ONGOING
                 "
                 :to="{
                     name: 'results',


### PR DESCRIPTION
On the project page, the "View Partial Report" button was displayed when no result were present.
This button was hidden when the analysis was in progress.
This fixes this problem.