### PR TITLE
Fix link to create integration

### DIFF
--- a/src/codeclarity_components/dashboard/components/DashboardStats.vue
+++ b/src/codeclarity_components/dashboard/components/DashboardStats.vue
@@ -305,7 +305,7 @@ fetchVcsIntegrations();
                     v-if="orgMetaData.integrations.length == 0"
                     :to="{
                         name: 'orgs',
-                        params: { orgId: defaultOrg!.id, page: 'integrations', action: 'add' }
+                        params: { orgId: defaultOrg!.id, page: 'integrations', action: 'manage' }
                     }"
                 >
                     <Button> Link to Github or Gitlab </Button>

--- a/src/codeclarity_components/organizations/integrations/IntegrationsList.vue
+++ b/src/codeclarity_components/organizations/integrations/IntegrationsList.vue
@@ -240,8 +240,13 @@ init();
                             "
                             class="integration-box-wrapper-item"
                             :to="{
-                                name: 'orgAddIntegration',
-                                params: { provider: IntegrationProvider.GITHUB }
+                                name: 'orgs',
+                                params: {
+                                    orgId: orgId,
+                                    page: 'integrations',
+                                    action: 'add',
+                                    provider: IntegrationProvider.GITHUB
+                                }
                             }"
                         >
                             <Card>

--- a/src/codeclarity_components/projects/list/ProjectsList.vue
+++ b/src/codeclarity_components/projects/list/ProjectsList.vue
@@ -136,7 +136,11 @@ fetchOrgMetaData();
                         v-if="orgMetaData.integrations.length == 0"
                         :to="{
                             name: 'orgs',
-                            params: { orgId: defaultOrg!.id, page: 'integrations', action: 'add' }
+                            params: {
+                                orgId: defaultOrg!.id,
+                                page: 'integrations',
+                                action: 'manage'
+                            }
                         }"
                     >
                         <Button> Link to Github or Gitlab </Button>


### PR DESCRIPTION
When no integration existed, the button on the dashboard redirected to the github integration formular.

It now redirects to the integration list to let the user chose between github or gitlab.