### PR TITLE
Add VLAI interface and update VulnList to display VLAI data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.0.22-alpha",
+  "version": "0.0.23-alpha",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/codeclarity_components/results/vulnerabilities/VulnList.vue
+++ b/src/codeclarity_components/results/vulnerabilities/VulnList.vue
@@ -364,6 +364,23 @@ watch(() => filterState.value.activeFilters, init);
                                                 }}</template>
                                             </SeverityBubble>
 
+                                            <SeverityBubble
+                                                v-for="vla in report.VLAI"
+                                                :key="vla.Source"
+                                                :critical="vla.Score == 'critical'"
+                                                :high="vla.Score == 'high'"
+                                                :medium="vla.Score == 'medium'"
+                                                :low="vla.Score == 'low'"
+                                                :none="vla.Score == 'none'"
+                                            >
+                                                <template #content
+                                                    >{{ vla.Source }}
+                                                    {{
+                                                        (vla.Confidence * 100).toFixed(1)
+                                                    }}%</template
+                                                >
+                                            </SeverityBubble>
+
                                             <!--------------------------------------------------------------------------->
                                             <!--                                CWE Info                               -->
                                             <!--------------------------------------------------------------------------->

--- a/src/codeclarity_components/results/vulnerabilities/VulnStats.ts
+++ b/src/codeclarity_components/results/vulnerabilities/VulnStats.ts
@@ -121,6 +121,13 @@ export interface VulnerabilityMerged {
     Description: string;
     WinningSource: string;
     Conflict: Conflict;
+    VLAI: VLAI[];
+}
+
+export interface VLAI {
+    Source: Source;
+    Score: string;
+    Confidence: number;
 }
 
 export interface AffectedDeps {


### PR DESCRIPTION
Introduce a new VLAI interface to manage vulnerability data and update the VulnList component to display VLAI information. Bump the version to 0.0.23-alpha.